### PR TITLE
Added watcher_name param to the tsuru Stream class

### DIFF
--- a/tsuru/plugins/__init__.py
+++ b/tsuru/plugins/__init__.py
@@ -134,12 +134,15 @@ class ProcfileWatcher(CircusPlugin):
         env = {"port": self.port, "PORT": self.port}
         env.update(common.load_envs(self.apprc))
         cmd = replace_args(cmd, **env)
+        stderr_stream = self.stderr_stream.copy()
+        stdout_stream = self.stdout_stream.copy()
+        stdout_stream["watcher_name"] = stderr_stream["watcher_name"] = name
         options = {
             "env": env,
             "copy_env": True,
             "working_dir": self.working_dir,
-            "stderr_stream": self.stderr_stream,
-            "stdout_stream": self.stdout_stream,
+            "stderr_stream": stderr_stream,
+            "stdout_stream": stdout_stream,
             "uid": self.uid,
             "hooks": {
                 "before_start": "tsuru.hooks.before_start",

--- a/tsuru/stream/__init__.py
+++ b/tsuru/stream/__init__.py
@@ -20,11 +20,13 @@ class Stream(object):
 
     def __init__(self, **kwargs):
         self.apprc = "/home/application/apprc"
+        self.watcher_name = kwargs.get("watcher_name", "")
 
     def __call__(self, data):
         appname, host, token = self.load_envs()
         if appname and host and token:
-            url = "{0}/apps/{1}/log".format(host, appname)
+            url = "{0}/apps/{1}/log?source={2}".format(host, appname,
+                                                       self.watcher_name)
             messages = extract_message(data["data"])
             requests.post(url, data=json.dumps(messages),
                           headers={"Authorization": "bearer " + token})

--- a/tsuru/tests/plugins/test_procfile_watcher.py
+++ b/tsuru/tests/plugins/test_procfile_watcher.py
@@ -24,8 +24,14 @@ class ProcfileWatcherTest(TestCase):
                     "env": {"port": "8888", "PORT": "8888"},
                     "copy_env": True,
                     "working_dir": "/home/application/current",
-                    "stderr_stream": {"class": "tsuru.stream.Stream"},
-                    "stdout_stream": {"class": "tsuru.stream.Stream"},
+                    "stderr_stream": {
+                        "class": "tsuru.stream.Stream",
+                        "watcher_name": name
+                    },
+                    "stdout_stream": {
+                        "class": "tsuru.stream.Stream",
+                        "watcher_name": name
+                    },
                     "uid": "ubuntu",
                     "hooks": {'before_start': "tsuru.hooks.before_start",
                               'after_start': "tsuru.hooks.after_start"},

--- a/tsuru/tests/stream/test_stream.py
+++ b/tsuru/tests/stream/test_stream.py
@@ -18,7 +18,7 @@ class StreamTestCase(unittest.TestCase):
             'data': l,
             'name': 'stderr'
         }
-        self.stream = Stream()
+        self.stream = Stream(watcher_name='mywatcher')
         self.stream.apprc = os.path.join(os.path.dirname(__file__),
                                          "testdata/apprc")
 
@@ -30,7 +30,7 @@ class StreamTestCase(unittest.TestCase):
         post.return_value = mock.Mock(status_code=200)
         self.stream(self.data)
         appname, host, token = self.stream.load_envs()
-        url = "{0}/apps/{1}/log".format(host, appname)
+        url = "{0}/apps/{1}/log?source=mywatcher".format(host, appname)
         expected_msg = "Starting gunicorn 0.15.0\n"
         expected_data = json.dumps([expected_msg])
         post.assert_called_with(url, data=expected_data,


### PR DESCRIPTION
The watcher name which is based on the Procfile entry is now sent as the target param to the Tsuru log service.

This will allow Tsuru to use it as a prefix when showing logs.
