### PR TITLE
Add optional configuration for statsd prefix via new environment variable.

### DIFF
--- a/tsuru/plugins/stats/statsd.py
+++ b/tsuru/plugins/stats/statsd.py
@@ -13,13 +13,20 @@ class StatsdBackend(object):
 
         app_name = envs.get("TSURU_APPNAME")
         host_name = socket.gethostname()
-        # tsuru.app.host
-        self.prefix = 'tsuru.{}.{}'.format(app_name, host_name)
-
+      
         # initialize statsd
         from circus.plugins.statsd import StatsdClient
         host = envs.get("STATSD_HOST", 'localhost') or "localhost"
         port = envs.get("STATSD_PORT", '8125') or "8125"
+        prefix = envs.get("STATSD_PREFIX", '') or ""
+
+        if not prefix:
+            statsd_prefix = "{}.".format(prefix)
+        else:
+            statsd_prefix = ""
+
+        # tsuru.app.host
+        self.prefix = '{}tsuru.{}.{}'.format(statsd_prefix, app_name, host_name)
 
         self.client = StatsdClient(
             host=host,

--- a/tsuru/plugins/stats/statsd.py
+++ b/tsuru/plugins/stats/statsd.py
@@ -13,7 +13,7 @@ class StatsdBackend(object):
 
         app_name = envs.get("TSURU_APPNAME")
         host_name = socket.gethostname()
-      
+
         # initialize statsd
         from circus.plugins.statsd import StatsdClient
         host = envs.get("STATSD_HOST", 'localhost') or "localhost"
@@ -26,7 +26,8 @@ class StatsdBackend(object):
             statsd_prefix = ""
 
         # tsuru.app.host
-        self.prefix = '{}tsuru.{}.{}'.format(statsd_prefix, app_name, host_name)
+        self.prefix = '{}tsuru.{}.{}'.format(
+            statsd_prefix, app_name, host_name)
 
         self.client = StatsdClient(
             host=host,

--- a/tsuru/plugins/stats/statsd.py
+++ b/tsuru/plugins/stats/statsd.py
@@ -18,10 +18,10 @@ class StatsdBackend(object):
         from circus.plugins.statsd import StatsdClient
         host = envs.get("STATSD_HOST", 'localhost') or "localhost"
         port = envs.get("STATSD_PORT", '8125') or "8125"
-        prefix = envs.get("STATSD_PREFIX", '') or ""
+        namespace = envs.get("STATSD_PREFIX", '') or ""
 
-        if not prefix:
-            statsd_prefix = "{}.".format(prefix)
+        if namespace != "":
+            statsd_prefix = "{}.".format(namespace)
         else:
             statsd_prefix = ""
 


### PR DESCRIPTION
Many hosted statsd services work by namespacing your metrics. However, this is currently not possible within a Tsuru application. This change to `tsuru-circus` allows an app to decide on where to send
statsd metrics around CPU, MEM and connections, allowing an app owner / team to run and support
their own application.

New environment variable:

* `STATSD_PREFIX` - A prefix to attach to all statsd metrics to enable self-service metrics to cloud based
providers.